### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -32,4 +32,4 @@ BinaryBuffer	KEYWORD1
 # Constants (LITERAL1)
 #######################################
 
-FAIL LITERAL1
+FAIL	LITERAL1


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords