### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -9,7 +9,7 @@
 PJON	KEYWORD1
 ModuleVariable	KEYWORD1
 ModuleVariableSet	KEYWORD1
-ModuleInterface  KEYWORD1
+ModuleInterface	KEYWORD1
 ModuleInterfaceSet	KEYWORD1
 PJONModuleInterface	KEYWORD1
 PJONModuleInterfaceSet	KEYWORD1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords