### PR TITLE
Correct strlen to strlen_P when accessing PROGMEM in ModuleVariable.h

### DIFF
--- a/src/MI/ModuleVariable.h
+++ b/src/MI/ModuleVariable.h
@@ -252,7 +252,7 @@ public:
   }
   
   static ModuleVariableType get_type(const char *type_name) {
-    uint8_t len = (uint8_t) strlen(get_mv_type_names()) / 2;
+    uint8_t len = (uint8_t) strlen_P(get_mv_type_names()) / 2;
     char name[3];
     for (uint8_t i = 0; i < len; i++) {
       name[0] = pgm_read_byte(&(get_mv_type_names()[i*2]));


### PR DESCRIPTION
Hi! I was unable to compile any of the examples for an ESP8266 board (a Wemos D1 Mini, to be specific) - a memory fault appeared to be causing an infinite reset when attempting to set the contract (which I found odd since it's the same board depicted in the images accompanying the https://github.com/fredilarsen/ModuleInterface/tree/master/examples/WebPage )

After some digging through the code, I believe I have found the problem:
In ModuleVariable.cpp, variable type names are stored in a PROGMEM char array:
```
const char ModuleVariableTypeNames[] PROGMEM = "--b1u1u2u4i1i2i4f4";
```

However, the length of this array is accessed using strlen() in the get_type() function:
```
uint8_t len = (uint8_t) strlen(get_mv_type_names()) / 2;
```

This appears to compile and run ok under AVR architecture (even though it shouldn't), but causes a memory fault on ESP8266 boards. The attached PR fixes this issue by using the strlen_P() function intead.
